### PR TITLE
Introduce AppKitView

### DIFF
--- a/lib/flutter_inline_webview_macos/flutter_inline_webview_macos.dart
+++ b/lib/flutter_inline_webview_macos/flutter_inline_webview_macos.dart
@@ -84,7 +84,7 @@ class InlineWebViewMacOsState extends State<InlineWebViewMacOs> {
       return SizedBox(
         height: widget.height,
         width: widget.width,
-        child: UiKitView(
+        child: AppKitView(
           key: _key,
           viewType: 'dev.akaboshinit/flutter_inline_webview_macos',
           onPlatformViewCreated: _onPlatformViewCreated,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_inline_webview_macos
 description: Flutter plugin for inline display of native WebView on macOS
-version: 0.0.6
+version: 0.0.7
 homepage: https://github.com/akaboshinit/flutter_inline_webview_macos
 issue_tracker: https://github.com/akaboshinit/flutter_inline_webview_macos/issues
 


### PR DESCRIPTION
This PR replaces the usage of UiKitView with AppKitView.

Regarding Flutter's docs, UiKitView widget is meant to be used in iOS (because it is implemented using [UIKit API](https://developer.apple.com/documentation/uikit), which is for other platforms rather like iOS, iPadOS, etc), while macOS applications/plugins should use AppKitView widget (because it is implemented using [AppKit API](https://developer.apple.com/documentation/appkit/) which is for macOS).